### PR TITLE
discord-plugged: Allow for overriding the discord package used

### DIFF
--- a/builder.nix
+++ b/builder.nix
@@ -1,6 +1,6 @@
 # Either builds a self contained package set, or can be an overlay if you set the overlayFinal arg
 # in which case it uses the overlay's fixed point and not its own built in one
-{ pkgs, replugged-src, themes ? { }, plugins ? { }, extraElectronArgs ? "", overlayFinal ? null }:
+{ pkgs, replugged-src, discord ? null, themes ? { }, plugins ? { }, extraElectronArgs ? "", overlayFinal ? null }:
 let
   overlayFinalOrSelf = if (overlayFinal == null) then self else overlayFinal;
   self =
@@ -18,6 +18,7 @@ let
       discord-plugged = pkgs.callPackage ./drvs/discord-plugged.nix {
         inherit extraElectronArgs;
         inherit (overlayFinalOrSelf) replugged;
+        inherit discord;
       };
     };
 in

--- a/drvs/discord-plugged.nix
+++ b/drvs/discord-plugged.nix
@@ -1,5 +1,6 @@
 { symlinkJoin
 , discord-canary
+, discord ? discord-canary
 , replugged
 , makeBinaryWrapper
 , writeShellScript
@@ -12,7 +13,7 @@ let
 in
 symlinkJoin {
   name = "discord-plugged";
-  paths = [ discord-canary.out ];
+  paths = [ discord.out ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
@@ -30,18 +31,18 @@ symlinkJoin {
         oldExe=$1; shift
         oldWrapperArgs=("$@")
       }
-      eval "parseMakeCWrapperCall ''${wrapperCmd//"${discord-canary.out}"/"$out"}"
+      eval "parseMakeCWrapperCall ''${wrapperCmd//"${discord.out}"/"$out"}"
       # Binary wrapper
       makeWrapper $oldExe $out/opt/DiscordCanary/DiscordCanary "''${oldWrapperArgs[@]}" --add-flags "${extraElectronArgs}"
     else
       # Normal wrapper
       substituteInPlace $out/opt/DiscordCanary/DiscordCanary \
-      --replace '${discord-canary.out}' "$out" \
+      --replace '${discord.out}' "$out" \
       --replace '"$@"' '${extraElectronArgs} "$@"'
     fi
 
-    substituteInPlace $out/opt/DiscordCanary/DiscordCanary --replace '${discord-canary.out}' "$out"
+    substituteInPlace $out/opt/DiscordCanary/DiscordCanary --replace '${discord.out}' "$out"
   '';
 
-  meta.mainProgram = if (discord-canary.meta ? mainProgram) then discord-canary.meta.mainProgram else null;
+  meta.mainProgram = if (discord.meta ? mainProgram) then discord.meta.mainProgram else null;
 }


### PR DESCRIPTION
When I used powercord-overlay, I overrode the discord-canary package something like this:

```nix
home.packages = [
  (pkgs.discord-plugged.override {
    discord-canary = pkgs.discord-canary.override {
      withOpenASAR = true;
    };
  })
];
```

I'm not sure if this is the preferred solution to get that same ability here, but this is what I tried.

